### PR TITLE
Fix autolink dict parameters not passed to lxml

### DIFF
--- a/html_sanitizer/sanitizer.py
+++ b/html_sanitizer/sanitizer.py
@@ -329,7 +329,7 @@ class Sanitizer(object):
 
             element = normalize_whitespace_in_text_or_tail(element)
 
-        if self.autolink:
+        if self.autolink is True:
             lxml.html.clean.autolink(doc)
         elif isinstance(self.autolink, dict):
             lxml.html.clean.autolink(doc, **self.autolink)


### PR DESCRIPTION
`if autolink:` apply whether the value is `True` or a dict, so `elif isinstance(self.autolink, dict):` is never executed.