### PR TITLE
Fix custom allowed attributes getting removed

### DIFF
--- a/html_sanitizer/sanitizer.py
+++ b/html_sanitizer/sanitizer.py
@@ -334,11 +334,16 @@ class Sanitizer(object):
         elif isinstance(self.autolink, dict):
             lxml.html.clean.autolink(doc, **self.autolink)
 
+        all_allowed_attrs = {
+            attr for attrs in self.attributes.values() for attr in attrs
+        }
+
         # Run cleaner again, but this time with even more strict settings
         lxml.html.clean.Cleaner(
             allow_tags=self.tags,
             remove_unknown_tags=False,
             safe_attrs_only=True,
+            safe_attrs=lxml.html.defs.safe_attrs | all_allowed_attrs,
             add_nofollow=self.add_nofollow,
             forms=False,
         )(doc)

--- a/html_sanitizer/sanitizer.py
+++ b/html_sanitizer/sanitizer.py
@@ -334,16 +334,11 @@ class Sanitizer(object):
         elif isinstance(self.autolink, dict):
             lxml.html.clean.autolink(doc, **self.autolink)
 
-        all_allowed_attrs = {
-            attr for attrs in self.attributes.values() for attr in attrs
-        }
-
         # Run cleaner again, but this time with even more strict settings
         lxml.html.clean.Cleaner(
             allow_tags=self.tags,
             remove_unknown_tags=False,
-            safe_attrs_only=True,
-            safe_attrs=lxml.html.defs.safe_attrs | all_allowed_attrs,
+            safe_attrs_only=False,
             add_nofollow=self.add_nofollow,
             forms=False,
         )(doc)

--- a/html_sanitizer/tests.py
+++ b/html_sanitizer/tests.py
@@ -372,3 +372,15 @@ class SanitizerTestCase(TestCase):
             ],
             sanitizer=sanitizer,
         )
+
+    def test_custom_allowed_attribute(self):
+        sanitizer = Sanitizer({"attributes": {"a": ("href", "custom")}})
+        self.run_tests(
+            [
+                (
+                    '<a href="http://example.com" custom="1" abc="2">Test</a>',
+                    '<a href="http://example.com" custom="1">Test</a>',
+                )
+            ],
+            sanitizer=sanitizer,
+        )


### PR DESCRIPTION
This fixes the last `Cleaner` operation, which removed all attributes not in the `lxml.html.defs.safe_attrs` set, without taking settings into account.