### PR TITLE
Make removing 'style' tags optional

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ Change log
 `Next version`_
 ===============
 
+- Be able to keep the ``<style>`` tag by adding it to ``tags``.
+
+
 `1.8`_ (2019-11-21)
 ====================
 

--- a/html_sanitizer/sanitizer.py
+++ b/html_sanitizer/sanitizer.py
@@ -255,8 +255,8 @@ class Sanitizer(object):
 
         lxml.html.clean.Cleaner(
             remove_unknown_tags=False,
-            # Remove style *tags*
-            style=True,
+            # Remove style *tags* if not explicitly allowed
+            style='style' not in self.tags,
             # Do not strip out style attributes; we still need the style
             # information to convert spans into em/strong tags
             safe_attrs_only=False,

--- a/html_sanitizer/tests.py
+++ b/html_sanitizer/tests.py
@@ -10,6 +10,7 @@ from .sanitizer import Sanitizer
 
 class SanitizerTestCase(TestCase):
     if not hasattr(TestCase, "subTest"):
+
         @contextmanager
         def subTest(self, *args, **kwargs):
             yield

--- a/html_sanitizer/tests.py
+++ b/html_sanitizer/tests.py
@@ -10,7 +10,6 @@ from .sanitizer import Sanitizer
 
 class SanitizerTestCase(TestCase):
     if not hasattr(TestCase, "subTest"):
-
         @contextmanager
         def subTest(self, *args, **kwargs):
             yield
@@ -454,4 +453,34 @@ Mitarbeitenden folgende geschäftlich bedingten Auslagen ersetzt:</font></p>
                 ('<a name="test"></a>', '<a name="test"></a>',),
                 ('<a id="test"></a>', '<a name="test"></a>',),
             ],
+        )
+
+    def test_style_tag(self):
+        # don't allow style tag (default)
+        self.run_tests(
+            [
+                ('foo<style>*{color: red}</style>bar', 'foobar'),
+            ],
+            sanitizer=Sanitizer({
+                "tags": {"impossible tag"},
+                "attributes": {},
+                "empty": set(),
+                "separate": set(),
+            })
+        )
+
+        # allow style tag
+        self.run_tests(
+            [
+                (
+                    'foo<style>*{color: red}</style>bar',
+                    'foo<style>*{color: red}</style>bar'
+                ),
+            ],
+            sanitizer=Sanitizer({
+                "tags": {"style"},
+                "attributes": {},
+                "empty": set(),
+                "separate": set(),
+            })
         )


### PR DESCRIPTION
Don't remove style tag when it's whitelisted using the `tags` configuration.