### PR TITLE
Manually overriding all whitespace replacement if someone wants to keep Typographic whitespaces

### DIFF
--- a/html_sanitizer/sanitizer.py
+++ b/html_sanitizer/sanitizer.py
@@ -51,7 +51,6 @@ def normalize_overall_whitespace(
 ):
     if keep_typographic_whitespace:
         return html
-        # remove all sorts of newline and nbsp characters
     whitespace = ["\xa0", "&nbsp;", "&#160;", "&#xa0;","\n", "&#10;", "&#xa;", "\r", "&#13;", "&#xd;"]
     if whitespace_re is None:
         whitespace_re = r"\s+"

--- a/html_sanitizer/sanitizer.py
+++ b/html_sanitizer/sanitizer.py
@@ -52,10 +52,10 @@ def normalize_overall_whitespace(
     if keep_typographic_whitespace:
         return html
     whitespace = ["\xa0", "&nbsp;", "&#160;", "&#xa0;","\n", "&#10;", "&#xa;", "\r", "&#13;", "&#xd;"]
-    if whitespace_re is None:
-        whitespace_re = r"\s+"
     for ch in whitespace:
         html = html.replace(ch, " ")
+    if whitespace_re is None:
+        whitespace_re = r"\s+"
     html = re.sub(whitespace_re, " ", html)
     return html
 

--- a/html_sanitizer/sanitizer.py
+++ b/html_sanitizer/sanitizer.py
@@ -49,10 +49,10 @@ typographic_whitespace = "".join(
 def normalize_overall_whitespace(
     html, keep_typographic_whitespace=False, whitespace_re=None
 ):
-    whitespace = []
-    if not keep_typographic_whitespace:
+    if keep_typographic_whitespace:
+        return html
         # remove all sorts of newline and nbsp characters
-        whitespace += ["\xa0", "&nbsp;", "&#160;", "&#xa0;","\n", "&#10;", "&#xa;", "\r", "&#13;", "&#xd;"]
+    whitespace = ["\xa0", "&nbsp;", "&#160;", "&#xa0;","\n", "&#10;", "&#xa;", "\r", "&#13;", "&#xd;"]
     if whitespace_re is None:
         whitespace_re = r"\s+"
     for ch in whitespace:

--- a/html_sanitizer/sanitizer.py
+++ b/html_sanitizer/sanitizer.py
@@ -49,11 +49,10 @@ typographic_whitespace = "".join(
 def normalize_overall_whitespace(
     html, keep_typographic_whitespace=False, whitespace_re=None
 ):
-    # remove all sorts of newline and nbsp characters
-    whitespace = ["\n", "&#10;", "&#xa;", "\r", "&#13;", "&#xd;"]
+    whitespace = []
     if not keep_typographic_whitespace:
-        # non-breaking space representations
-        whitespace += ["\xa0", "&nbsp;", "&#160;", "&#xa0;"]
+        # remove all sorts of newline and nbsp characters
+        whitespace += ["\xa0", "&nbsp;", "&#160;", "&#xa0;","\n", "&#10;", "&#xa;", "\r", "&#13;", "&#xd;"]
     if whitespace_re is None:
         whitespace_re = r"\s+"
     for ch in whitespace:

--- a/html_sanitizer/tests.py
+++ b/html_sanitizer/tests.py
@@ -428,6 +428,14 @@ Mitarbeitenden folgende geschäftlich bedingten Auslagen ersetzt:</font></p>
                     "\u2003\u2009\u205f\u2005\u2006\u2008\u3000",
                     "\u200a\u2003\u202f\u2004\xa0\u2007\u2002\u2002"
                     "\u2003\u2009\u205f\u2005\u2006\u2008\u3000",
+                ),
+                (
+                    "Hello This is a paragraph. \n"
+                    "\tHello. This is a tabled line."
+                    "Hello.This is beginning of the end.\r",
+                    "Hello This is a paragraph. \n"
+                    "\tHello. This is a tabled line."
+                    "Hello.This is beginning of the end.\r"
                 )
             ],
             sanitizer=sanitizer,


### PR DESCRIPTION
If paragraph breaks and tabs are used for styling; it should completely bypass whitespace normalisation instead of just bypassing NBSP & few others 