### PR TITLE
Whitespaces are mantained even after a tag

### DIFF
--- a/html_sanitizer/sanitizer.py
+++ b/html_sanitizer/sanitizer.py
@@ -112,17 +112,19 @@ def anchor_id_to_name(element):
     return element
 
 
-def normalize_whitespace_in_text_or_tail(element, whitespace_re=None):
+def normalize_whitespace_in_text_or_tail(
+    element, whitespace_re=None, keep_whitespaces=None
+):
     if whitespace_re is None:
         whitespace_re = re.compile(r"\s+")
-    if element.text:
+    if element.text and not keep_whitespaces:
         while True:
             text = whitespace_re.sub(" ", element.text)
             if element.text == text:
                 break
             element.text = text
 
-    if element.tail:
+    if element.tail and not keep_whitespaces:
         while True:
             text = whitespace_re.sub(" ", element.tail)
             if element.tail == text:
@@ -290,7 +292,9 @@ class Sanitizer:
                 element = processor(element)
 
             element = normalize_whitespace_in_text_or_tail(
-                element, whitespace_re=self.whitespace_re
+                element,
+                whitespace_re=self.whitespace_re,
+                keep_whitespaces=self.keep_typographic_whitespace,
             )
 
             # remove empty tags if they are not explicitly allowed
@@ -392,7 +396,9 @@ class Sanitizer:
                 element.set("href", self.sanitize_href(href))
 
             element = normalize_whitespace_in_text_or_tail(
-                element, whitespace_re=self.whitespace_re
+                element,
+                whitespace_re=self.whitespace_re,
+                keep_whitespaces=self.keep_typographic_whitespace,
             )
 
         if self.autolink is True:

--- a/html_sanitizer/sanitizer.py
+++ b/html_sanitizer/sanitizer.py
@@ -113,18 +113,18 @@ def anchor_id_to_name(element):
 
 
 def normalize_whitespace_in_text_or_tail(
-    element, whitespace_re=None, keep_whitespaces=None
+    element, whitespace_re=None, keep_typographic_whitespace=False
 ):
     if whitespace_re is None:
         whitespace_re = re.compile(r"\s+")
-    if element.text and not keep_whitespaces:
+    if element.text and not keep_typographic_whitespace:
         while True:
             text = whitespace_re.sub(" ", element.text)
             if element.text == text:
                 break
             element.text = text
 
-    if element.tail and not keep_whitespaces:
+    if element.tail and not keep_typographic_whitespace:
         while True:
             text = whitespace_re.sub(" ", element.tail)
             if element.tail == text:
@@ -294,7 +294,7 @@ class Sanitizer:
             element = normalize_whitespace_in_text_or_tail(
                 element,
                 whitespace_re=self.whitespace_re,
-                keep_whitespaces=self.keep_typographic_whitespace,
+                keep_typographic_whitespace=self.keep_typographic_whitespace,
             )
 
             # remove empty tags if they are not explicitly allowed
@@ -398,7 +398,7 @@ class Sanitizer:
             element = normalize_whitespace_in_text_or_tail(
                 element,
                 whitespace_re=self.whitespace_re,
-                keep_whitespaces=self.keep_typographic_whitespace,
+                keep_typographic_whitespace=self.keep_typographic_whitespace,
             )
 
         if self.autolink is True:

--- a/html_sanitizer/tests.py
+++ b/html_sanitizer/tests.py
@@ -431,8 +431,8 @@ Mitarbeitenden folgende geschäftlich bedingten Auslagen ersetzt:</font></p>
                     "Hello.This is beginning of the end.\r",
                 ),
                 (
-                    "something    <br>somethinglse    ",
-                    "something    <br>somethinglse    ",
+                    "something    <br>somethingelse    ",
+                    "something    <br>somethingelse    ",
                 ),
             ],
             sanitizer=sanitizer,

--- a/html_sanitizer/tests.py
+++ b/html_sanitizer/tests.py
@@ -430,6 +430,10 @@ Mitarbeitenden folgende geschäftlich bedingten Auslagen ersetzt:</font></p>
                     "\tHello. This is a tabled line."
                     "Hello.This is beginning of the end.\r",
                 ),
+                (
+                    "something    <br>somethinglse    ",
+                    "something    <br>somethinglse    ",
+                ),
             ],
             sanitizer=sanitizer,
         )


### PR DESCRIPTION
The PR of the #31  [changes we discussed before](https://github.com/matthiask/html-sanitizer/issues/31).

Now the whitespaces are maintained even after a tag