### PR TITLE
Prevent space between merged tags of the same type

### DIFF
--- a/html_sanitizer/sanitizer.py
+++ b/html_sanitizer/sanitizer.py
@@ -362,12 +362,12 @@ class Sanitizer:
                     # tags of a mergeable type.
                     if nx.text:
                         if len(element):
-                            list(element)[-1].tail = "{} {}".format(
+                            list(element)[-1].tail = "{}{}".format(
                                 list(element)[-1].tail or "",
                                 nx.text,
                             )
                         else:
-                            element.text = "{} {}".format(element.text or "", nx.text)
+                            element.text = "{}{}".format(element.text or "", nx.text)
 
                     for child in nx:
                         element.append(child)

--- a/html_sanitizer/tests.py
+++ b/html_sanitizer/tests.py
@@ -97,10 +97,14 @@ class SanitizerTestCase(TestCase):
 
     def test_03_merge(self):
         entries = (
-            ("<h2>foo</h2><h2>bar</h2>", "<h2>foo bar</h2>"),
+            ("<h2>foo</h2><h2>bar</h2>", "<h2>foobar</h2>"),
             ("<h2>foo  </h2>   <h2>   bar</h2>", "<h2>foo bar</h2> "),
         )
 
+        self.run_tests(entries)
+
+    def test_no_space_between_same_tags(self):
+        entries = [("<strong>Hel</strong><strong>lo</strong>", "<strong>Hello</strong>")]
         self.run_tests(entries)
 
     def test_04_p_in_li(self):
@@ -275,7 +279,7 @@ class SanitizerTestCase(TestCase):
                 (
                     '<p class="centered">Test <span class="bla">span</span>'
                     '<span class="blub">span</span></p>',
-                    '<p class="centered">Test <span class="bla">span span</span></p>',
+                    '<p class="centered">Test <span class="bla">spanspan</span></p>',
                 ),
                 ('<h1 class="centered">Test</h1>', '<h1 class="centered">Test</h1>'),
                 ('<h2 class="centered">Test</h2>', "<h2>Test</h2>"),
@@ -311,7 +315,7 @@ class SanitizerTestCase(TestCase):
                 (
                     '<p class="centered">Test <span class="bla">span</span>'
                     '<span class="bla">span</span></p>',
-                    '<p class="centered">Test <span class="bla">span span</span></p>',
+                    '<p class="centered">Test <span class="bla">spanspan</span></p>',
                 ),
             ],
             sanitizer=sanitizer,


### PR DESCRIPTION
Fixes #35.

I was a little unsure about the change on line 365 - the tests pass with or without it, but it seemed right to also change it. Maybe you can shed some light on what that `if` does.