### PR TITLE
Use dependency `lxml[html_clean]`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install beautifulsoup4 lxml
+          python -m pip install beautifulsoup4 lxml[html_clean]
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Run tests
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 ]
 dependencies = [
   "beautifulsoup4",
-  "lxml[html_clean]>=4.9.1",
+  "lxml[html_clean]>=5.2.0",
 ]
 [project.urls]
 Homepage = "https://github.com/matthiask/html-sanitizer/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 ]
 dependencies = [
   "beautifulsoup4",
-  "lxml>=4.9.1",
+  "lxml[html_clean]>=4.9.1",
 ]
 [project.urls]
 Homepage = "https://github.com/matthiask/html-sanitizer/"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [testenv]
 deps =
     wheel
-    lxml
+    lxml[html_clean]
     beautifulsoup4
     coverage
 changedir = {toxinidir}


### PR DESCRIPTION
Fixes #38

New verion of `lxml` (5.2.0) extracted the `lxml.html.clean` implementation into a separate library.
This pull request switches dependency from `lxml` to `lxml[html_clean]`.