### PR TITLE
Drop `lxml[html_clean]` and use `lxml_html_clean`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install beautifulsoup4 lxml[html_clean]
+          python -m pip install beautifulsoup4 lxml lxml-html-clean
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Run tests
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ dynamic = [
 ]
 dependencies = [
   "beautifulsoup4",
-  "lxml[html_clean]>=5.2.0",
+  "lxml>=5.2.0",
+  "lxml-html-clean>=0.1.0",
 ]
 [project.urls]
 Homepage = "https://github.com/matthiask/html-sanitizer/"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [testenv]
 deps =
     wheel
-    lxml[html_clean]
+    lxml
+    lxml-html-clean
     beautifulsoup4
     coverage
 changedir = {toxinidir}


### PR DESCRIPTION
Fixes #40

This PR drops dependency `lxml[html_clean]` since the extra is not resolved properly by `pip`. Instead, we use both `lxml` (5.2.0) and `lxml-html-clean` (0.1.0).