### PR TITLE
Added: setting for unescaping special chars (#46)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ dist
 .tox
 .coverage
 htmlcov
+venv/*
+exclude/*

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,7 @@ The default settings are::
         ],
         "element_postprocessors": [],
         "is_mergeable": lambda e1, e2: True,
+        "unescape_special_chars": False,
     }
 
 The keys' meaning is as follows:
@@ -107,6 +108,8 @@ The keys' meaning is as follows:
   merged by default. This callable can be used to prevent merging of
   adjacent elements e.g. when their classes do not match
   (``lambda e1, e2: e1.get('class') == e2.get('class')``)
+- ``unescape_special_chars``: Whether to unescape pecial characters like 
+  &, <, and > which are escaped by default. 
 
 Settings can be specified partially when initializing a sanitizer
 instance, but are still checked for consistency. For example, it is not

--- a/html_sanitizer/sanitizer.py
+++ b/html_sanitizer/sanitizer.py
@@ -175,6 +175,7 @@ DEFAULT_SETTINGS = {
         anchor_id_to_name,
     ],
     "element_postprocessors": [],
+    "unescape_special_chars": False, # see discussion https://github.com/matthiask/html-sanitizer/issues/46
 }
 
 
@@ -431,5 +432,13 @@ class Sanitizer:
 
         # remove wrapping tag needed by XML parser
         html = re.sub(r"^<div>|</div>$", "", html)
+
+        # see discussion https://github.com/matthiask/html-sanitizer/issues/46
+        if self.unescape_special_chars:
+            html = ( html
+                    .replace("&amp;", "&")
+                    .replace("&lt;", "<")
+                    .replace("&gt;", ">")
+            )
 
         return html


### PR DESCRIPTION
Based on discussion in https://github.com/matthiask/html-sanitizer/issues/46. I added a default setting called "unescape_special_chars". 

```python
DEFAULT_SETTINGS = {
    ...
    "unescape_special_chars": False, # see discussion https://github.com/matthiask/html-sanitizer/issues/46
}
```

When true, special characters are added back to the HTML immediately before returning:

```python
        # see discussion https://github.com/matthiask/html-sanitizer/issues/46
        if self.unescape_special_chars:
            html = ( html
                    .replace("&amp;", "&")
                    .replace("&lt;", "<")
                    .replace("&gt;", ">")
            )
```

I welcome feedback. This is a minimalist change intended only to give end users the ability to retain some of the special characters that are stripped out during the sanitation process. If I have broken assumptions, or if I have missed other special characters, please feel free to make note of these and I am happy to make further changes before the code is merged.